### PR TITLE
도트 토글, 아웃라인 토글 버그 수정

### DIFF
--- a/packages/css/component/toggle.css
+++ b/packages/css/component/toggle.css
@@ -519,18 +519,15 @@
   cursor: not-allowed;
 }
 
-.n-toggle-type\:dot:disabled::before,
-.n-toggle-type\:dot:checked:disabled::before,
-.n-toggle-type\:dot.n-toggle-status\:disabled::before,
-.n-toggle-type\:dot.n-toggle-status\:disabled::before,
-.n-toggle-type\:dot.disabled::before,
-.n-toggle\:dot:disabled::before,
-.n-toggle\:dot:checked:disabled::before,
-.n-toggle\:dot.n-toggle-status\:disabled::before,
-.n-toggle\:dot.disabled::before {
-  --n-dot-disabled-bg-color-before: rgba(var(--rgb-base-10), 0.27);
+.toggle-type\:dot:checked:disabled::before,
+.toggle-type\:dot.checked:disabled::before,
+.toggle-type\:dot.checked.disabled::before,
+.toggle\:dot:checked:disabled::before,
+.toggle\:dot:checked.disabled::before,
+.toggle\:dot.checked.disabled::before {
+  --dot-disabled-bg-color-before: rgba(var(--rgb-base-10), 0.27);
 
-  background-color: var(--n-dot-disabled-bg-color-before);
+  background-color: var(--dot-disabled-bg-color-before);
 }
 
 /* ---- n-toggle:outline ------------------------------------------------- */
@@ -592,7 +589,7 @@
 .n-toggle\:outline.n-toggle-status\:checked,
 .n-toggle\:outline.checked {
   background-color: var(--color-main-2);
-  border: transparent;
+  border-color: transparent;
   color: var(--color-base-1);
 }
 
@@ -687,7 +684,7 @@
   --n-outline-disabled-bg-color: rgba(var(--rgb-base-10), 0.05);
   --n-outline-disabled-color: rgba(var(--rgb-base-10), 0.27);
 
-  border: transparent;
+  border-color: transparent;
   background-color: var(--n-outline-disabled-bg-color);
   color: var(--n-outline-disabled-color);
   cursor: not-allowed;


### PR DESCRIPTION
* 도트 토글 기본 disabled 상태가 checked disabled 상태인 버그 수정
```css
.toggle-type\:dot:checked:disabled::before,
.toggle-type\:dot.checked:disabled::before,
.toggle-type\:dot.checked.disabled::before,
.toggle\:dot:checked:disabled::before,
.toggle\:dot:checked.disabled::before,
.toggle\:dot.checked.disabled::before {
  --dot-disabled-bg-color-before: rgba(var(--rgb-base-10), 0.27);

  background-color: var(--dot-disabled-bg-color-before);
}

```
* 아웃라인 border:transparent 속성 적용으로 인해 기본 상태와 체크 상태 크기 달라지는 버그 수정
  - border:transparent -> border-color:transparent 변경