### PR TITLE
feat/21-card 옵션 및 타입 추가

### DIFF
--- a/css/component/m3/m3-card.css
+++ b/css/component/m3/m3-card.css
@@ -47,13 +47,13 @@
         --card-font-color: var(--color-base-10);
     }
 
-    .card\:elevated.card\:focused{
+    .card\:elevated.card-state\:focused{
         --card-focused-outline-color: var(--color-base-10);
     }
-    .card\:filled.card\:focused{
+    .card\:filled.card-state\:focused{
         --card-focused-outline-color: var(--color-base-10);
     }
-    .card\:outlined.card\:focused {
+    .card\:outlined.card-state\:focused {
         --card-border: 1px solid var(--card-border-outline-color);
         --card-outlined-color: var(--color-base-10);
         --card-outline: 3px solid var(--card-outlined-color);
@@ -87,25 +87,25 @@
 
 /* ================ Elevated-type ================ */
 
-.card\:elevated.card\:enabled {
+.card\:elevated.card-state\:enabled {
     --card-opacity: var(--opacity-100);
     --card-box-shadow: 0 var(--space-1) var(--space-3) rgba(0, 0, 0, 0.12),
         0 var(--space-1) var(--space-2) rgba(0, 0, 0, 0.14);
 }
 
-.card\:elevated.card\:disabled {
+.card\:elevated.card-state\:disabled {
     --card-opacity: 0.38;
     --card-box-shadow: 0 var(--space-2) var(--space-4) rgba(0, 0, 0, 0.14);
     --card-cursor: var(--cursor-not-allowed);
 }
 
-.card\:elevated.card\:hovered {
+.card\:elevated.card-state\:hovered {
     --card-box-shadow: 0 var(--space-2) var(--space-4) rgba(0, 0, 0, 0.14),
         0 var(--space-3) var(--space-4) rgba(0, 0, 0, 0.12);
     filter: brightness(0.92);
 }
 
-.card\:elevated.card\:focused {
+.card\:elevated.card-state\:focused {
     --card-box-shadow: 0 var(--space-1) var(--space-3) rgba(0, 0, 0, 0.12),
         0 var(--space-1) var(--space-2) rgba(0, 0, 0, 0.14);
     --card-outline: 2px solid var(--card-focused-outline-color);
@@ -113,7 +113,7 @@
     filter: brightness(0.90);
 }
 
-.card\:elevated.card\:dragged {
+.card\:elevated.card-state\:dragged {
     --card-box-shadow: 0 var(--space-6) var(--space-10) rgba(0, 0, 0, 0.14),
         0 var(--space-4) var(--space-5) rgba(0, 0, 0, 0.12);
     --card-transform: scale(1.02);
@@ -123,31 +123,31 @@
 
 /* ================  Filled-type ================ */
 
-.card\:filled.card\:enabled {
+.card\:filled.card-state\:enabled {
     --card-opacity: var(--opacity-100);
     --card-box-shadow: none;
 }
 
-.card\:filled.card\:disabled {
+.card\:filled.card-state\:disabled {
     --card-opacity: 0.38;
     --card-box-shadow: none;
     --card-cursor: var(--cursor-not-allowed);
 }
 
-.card\:filled.card\:hovered {
+.card\:filled.card-state\:hovered {
     --card-box-shadow: 0 var(--space-1) var(--space-3) rgba(0, 0, 0, 0.12),
         0 var(--space-1) var(--space-2) rgba(0, 0, 0, 0.14);
     filter: brightness(0.92);
 }
 
-.card\:filled.card\:focused {
+.card\:filled.card-state\:focused {
     --card-box-shadow: none;
     --card-outline: 2px solid var(--card-focused-outline-color);
     --card-outline-offset: var(--space-2);
     filter: brightness(0.90);
 }
 
-.card\:filled.card\:dragged {
+.card\:filled.card-state\:dragged {
     --card-box-shadow: 0 var(--space-4) var(--space-8) rgba(0, 0, 0, 0.14),
         0 var(--space-3) var(--space-4) rgba(0, 0, 0, 0.12);
     --card-transform: scale(1.02);
@@ -157,27 +157,27 @@
 
 /* ================ Outlined-type ================ */
 
-.card\:outlined.card\:enabled {
+.card\:outlined.card-state\:enabled {
     --card-opacity: var(--opacity-100);
     --card-box-shadow: none;
     --card-border: 1px solid var(--card-border-outline-color);
 }
 
-.card\:outlined.card\:disabled {
+.card\:outlined.card-state\:disabled {
     --card-opacity: 0.38;
     --card-box-shadow: none;
     --card-border: 1px solid var(--card-border-outline-color);
     --card-cursor: var(--cursor-not-allowed);
 }
 
-.card\:outlined.card\:hovered {
+.card\:outlined.card-state\:hovered {
     --card-box-shadow: 0 var(--space-1) var(--space-3) rgba(0, 0, 0, 0.12),
         0 var(--space-1) var(--space-2) rgba(0, 0, 0, 0.14);
     --card-border: 1px solid var(--card-border-outline-color);
     filter: brightness(0.92);
 }
 
-.card\:outlined.card\:focused {
+.card\:outlined.card-state\:focused {
     --card-box-shadow: none;
     --card-border: 1px solid var(--card-focused-outline-color);
     --card-outline: 2px solid var(--card-focused-outline-color);
@@ -186,7 +186,7 @@
 }
 
 
-.card\:outlined.card\:dragged {
+.card\:outlined.card-state\:dragged {
     --card-box-shadow: 0 var(--space-6) var(--space-10) rgba(0, 0, 0, 0.14),
         0 var(--space-4) var(--space-5) rgba(0, 0, 0, 0.12);
     --card-border: 1px solid var(--card-border-outline-color);

--- a/css/component/m3/m3-card.css
+++ b/css/component/m3/m3-card.css
@@ -22,9 +22,13 @@
     --card-outline-offset: 0;
     --card-transform: none;
     
-    /* 상태별 변수 */
-    --card-focused-outline-color: var(--color-base-8);
+    /* font */
+    --card-font-color: var(--color-base-10);
     
+    /* 상태별 변수 */
+    --card-focused-outline-color: var(--color-base-10);
+    --card-border-outline-color: var(--color-base-10);
+    --card-outlined-color: var(--color-base-10);
     /* overlay */
     --card-overflow: var(--overflow-hidden);
 
@@ -33,55 +37,26 @@
     --card-transition: box-shadow var(--duration-5) var(--ease-out),
         transform var(--duration-5) var(--ease-out),
         opacity var(--duration-5) var(--ease-out);
-
-    /* ========== 카드 내부 컨텐츠의 변수 선언(기본값) ========== */
-    /* boxing */
-    --card-content-padding: var(--space-10);
-    
-    /* ========== 카드 내부 헤드라인의 변수 선언(기본값) ========== */
-    /* boxing */
-    --card-headline-margin-bottom: var(--space-3);
-
-    /* font */
-    --card-headline-font-size: var(--size-15);
-    --card-headline-font-weight: var(--font-weight-semibold);
-    --card-headline-color: var(--color-base-10);
-    --card-headline-line-height: var(--size-19);
-    --card-headline-letter-spacing: 0;
-
-    /* ========== 카드 내부 서브헤드의 변수 선언(기본값) ========== */
-    /* boxing */
-    --card-subhead-margin-bottom: var(--space-3);
-
-    /* font */
-    --card-subhead-font-size: var(--size-10);
-    --card-subhead-font-weight: var(--font-weight-normal);
-    --card-subhead-color: var(--color-base-8);
-    --card-subhead-line-height: var(--size-13);
-    --card-subhead-letter-spacing: 0;
-
-    /* font */
-    --card-supporting-text-font-size: var(--size-6);
-    --card-supporting-text-font-weight: var(--font-weight-normal);
-    --card-supporting-text-color: var(--color-base-10);
-    --card-supporting-text-line-height: var(--size-9);
-    --card-supporting-text-margin-bottom: var(--space-2);
-    --card-supporting-text-letter-spacing: 0;
 }
-
 /* ====== 다크 모드 ====== */
 
 @media (prefers-color-scheme: dark) {
     .m3-card {
         /* 다크모드에서 변경되는 변수들만 재정의 */
         --card-background: var(--color-base-2);
-        --card-headline-color: var(--color-base-10);
-        --card-subhead-color: var(--color-base-8);
-        --card-supporting-text-color: var(--color-base-9);
+        --card-font-color: var(--color-base-10);
     }
 
-    .m3-card.card-state\:focused {
-        --card-focused-outline-color: var(--color-accent-2);
+    .card\:elevated.card\:focused{
+        --card-focused-outline-color: var(--color-base-10);
+    }
+    .card\:filled.card\:focused{
+        --card-focused-outline-color: var(--color-base-10);
+    }
+    .card\:outlined.card\:focused {
+        --card-border: 1px solid var(--card-border-outline-color);
+        --card-outlined-color: var(--color-base-10);
+        --card-outline: 3px solid var(--card-outlined-color);
     }
 }
 
@@ -101,6 +76,7 @@
     outline: var(--card-outline);
     outline-offset: var(--card-outline-offset);
     transform: var(--card-transform);
+    color: var(--card-font-color);
     /* layout */
     overflow: var(--card-overflow);
 
@@ -109,38 +85,114 @@
     transition: var(--card-transition);
 }
 
-/* 카드 상태 */
-.m3-card.card-state\:enabled {
+/* ================ Elevated-type ================ */
+
+.card\:elevated.card\:enabled {
     --card-opacity: var(--opacity-100);
-    --card-box-shadow: 0px solid black;
+    --card-box-shadow: 0 var(--space-1) var(--space-3) rgba(0, 0, 0, 0.12),
+        0 var(--space-1) var(--space-2) rgba(0, 0, 0, 0.14);
 }
 
-.m3-card.card-state\:disabled,
-.m3-card.card-state\:disabled button {
-    --card-opacity: var(--opacity-60);
+.card\:elevated.card\:disabled {
+    --card-opacity: 0.38;
+    --card-box-shadow: 0 var(--space-2) var(--space-4) rgba(0, 0, 0, 0.14);
     --card-cursor: var(--cursor-not-allowed);
 }
 
-.m3-card.card-state\:hovered {
-    --card-box-shadow: 0 var(--space-4) var(--space-4) rgba(0, 0, 0, 0.16),
-        0 var(--space-2) var(--space-4) rgba(0, 0, 0, 0.23);
-    --card-opacity: var(--opacity-90);
+.card\:elevated.card\:hovered {
+    --card-box-shadow: 0 var(--space-2) var(--space-4) rgba(0, 0, 0, 0.14),
+        0 var(--space-3) var(--space-4) rgba(0, 0, 0, 0.12);
+    filter: brightness(0.92);
 }
 
-.m3-card.card-state\:focused {
-    --card-box-shadow: 0 var(--space-4) var(--space-4) rgba(0, 0, 0, 0.16),
-        0 var(--space-2) var(--space-4) rgba(0, 0, 0, 0.23);
-    --card-outline: 3px solid var(--card-focused-outline-color);
+.card\:elevated.card\:focused {
+    --card-box-shadow: 0 var(--space-1) var(--space-3) rgba(0, 0, 0, 0.12),
+        0 var(--space-1) var(--space-2) rgba(0, 0, 0, 0.14);
+    --card-outline: 2px solid var(--card-focused-outline-color);
     --card-outline-offset: var(--space-2);
-    --card-opacity: var(--opacity-90);
+    filter: brightness(0.90);
 }
 
-.m3-card.card-state\:dragged {
-    --card-box-shadow: 0 var(--space-4) var(--space-10) rgba(0, 0, 0, var(--opacity-25)),
-        0 var(--space-6) var(--space-6) rgba(0, 0, 0, var(--opacity-30));
+.card\:elevated.card\:dragged {
+    --card-box-shadow: 0 var(--space-6) var(--space-10) rgba(0, 0, 0, 0.14),
+        0 var(--space-4) var(--space-5) rgba(0, 0, 0, 0.12);
     --card-transform: scale(1.02);
-    --card-opacity: var(--opacity-80);
-    --card-cursor: var(--cursor-grap);
+    --card-cursor: var(--cursor-grab);
+    filter: brightness(0.84);
+}
+
+/* ================  Filled-type ================ */
+
+.card\:filled.card\:enabled {
+    --card-opacity: var(--opacity-100);
+    --card-box-shadow: none;
+}
+
+.card\:filled.card\:disabled {
+    --card-opacity: 0.38;
+    --card-box-shadow: none;
+    --card-cursor: var(--cursor-not-allowed);
+}
+
+.card\:filled.card\:hovered {
+    --card-box-shadow: 0 var(--space-1) var(--space-3) rgba(0, 0, 0, 0.12),
+        0 var(--space-1) var(--space-2) rgba(0, 0, 0, 0.14);
+    filter: brightness(0.92);
+}
+
+.card\:filled.card\:focused {
+    --card-box-shadow: none;
+    --card-outline: 2px solid var(--card-focused-outline-color);
+    --card-outline-offset: var(--space-2);
+    filter: brightness(0.90);
+}
+
+.card\:filled.card\:dragged {
+    --card-box-shadow: 0 var(--space-4) var(--space-8) rgba(0, 0, 0, 0.14),
+        0 var(--space-3) var(--space-4) rgba(0, 0, 0, 0.12);
+    --card-transform: scale(1.02);
+    --card-cursor: var(--cursor-grab);
+    filter: brightness(0.84);
+}
+
+/* ================ Outlined-type ================ */
+
+.card\:outlined.card\:enabled {
+    --card-opacity: var(--opacity-100);
+    --card-box-shadow: none;
+    --card-border: 1px solid var(--card-border-outline-color);
+}
+
+.card\:outlined.card\:disabled {
+    --card-opacity: 0.38;
+    --card-box-shadow: none;
+    --card-border: 1px solid var(--card-border-outline-color);
+    --card-cursor: var(--cursor-not-allowed);
+}
+
+.card\:outlined.card\:hovered {
+    --card-box-shadow: 0 var(--space-1) var(--space-3) rgba(0, 0, 0, 0.12),
+        0 var(--space-1) var(--space-2) rgba(0, 0, 0, 0.14);
+    --card-border: 1px solid var(--card-border-outline-color);
+    filter: brightness(0.92);
+}
+
+.card\:outlined.card\:focused {
+    --card-box-shadow: none;
+    --card-border: 1px solid var(--card-focused-outline-color);
+    --card-outline: 2px solid var(--card-focused-outline-color);
+    --card-outline-offset: var(--space-2);
+    filter: brightness(0.90);
+}
+
+
+.card\:outlined.card\:dragged {
+    --card-box-shadow: 0 var(--space-6) var(--space-10) rgba(0, 0, 0, 0.14),
+        0 var(--space-4) var(--space-5) rgba(0, 0, 0, 0.12);
+    --card-border: 1px solid var(--card-border-outline-color);
+    --card-transform: scale(1.02);
+    --card-cursor: var(--cursor-grab);
+    filter: brightness(0.84);
 }
 
 /* 카드 컨텐츠 */
@@ -148,29 +200,3 @@
     padding: var(--card-content-padding);
     
 }
-
-.m3-card .headline {
-    font-size: var(--card-headline-font-size);
-    font-weight: var(--card-headline-font-semibold);
-    color: var(--card-headline-color);
-    line-height: var(--card-headline-line-height);
-    margin-bottom: var(--card-headline-margin-bottom);
-    letter-spacing: var(--card-headline-letter-spacing);
-}
-
-.m3-card .subhead {
-    font-size: var(--card-subhead-font-size);
-    font-weight: var(--card-subhead-font-weight);
-    color: var(--card-subhead-color);
-    line-height: var(--card-subhead-line-height);
-    margin-bottom: var(--card-subhead-margin-bottom);
-    letter-spacing: var(--card-subhead-letter-spacing);
-}
-.m3-card .supporting-text {
-    font-size: var(--card-supporting-text-font-size);
-    font-weight: var(--card-supporting-text-font-weight);
-    color: var(--card-supporting-text-color);
-    line-height: var(--card-supporting-text-line-height);
-    margin-bottom: var(--card-supporting-text-margin-bottom);
-    letter-spacing: var(--card-supporting-text-letter-spacing);
-}   


### PR DESCRIPTION
## 설명

Material Design 3 Card 컴포넌트에 포괄적인 상태 관리 기능을 구현했습니다.
연관된 이슈: #21 /feature: 카드의 타입을 추가해주세요/

### 변경 및 추가사항
- 세 가지 카드 변형 추가: Elevated, Filled, Outlined
- 각 변형에 대한 5가지 인터랙티브 상태 구현:
  - **Enabled**: 기본 활성 상태
  - **Disabled**: 낮은 불투명도의 비활성 상태
  - **Hovered**: 향상된 그림자와 밝기 효과
  - **Focused**: 윤곽선 표시 및 밝기 조정
  - **Dragged**: 최대 그림자와 확대 효과
- 쉬운 커스터마이징과 테마 지원을 위한 CSS 커스텀 속성 활용
- `prefers-color-scheme`을 통한 다크 모드 지원

### 기술적 세부사항
- BEM과 유사한 네이밍 컨벤션을 사용한 상태 기반 스타일링 (예: `card:elevated.card-state:hovered`)
- box-shadow, transform, opacity에 대한 부드러운 전환 효과
- outline offset을 활용한 접근성 있는 포커스 표시
- 각 상태에 맞는 커서 피드백 (pointer, grab, not-allowed)
<img width="972" height="704" alt="card 옵션 추가" src="https://github.com/user-attachments/assets/9eddbb22-b144-443a-b73b-c0df4966091f" />
